### PR TITLE
Fix mobile UI bug

### DIFF
--- a/src/components/Chat/ChatBubble.tsx
+++ b/src/components/Chat/ChatBubble.tsx
@@ -10,8 +10,13 @@ interface Props {
 
 const ChatBubble: React.FC<Props> = ({ children, isResponse, isLocationResponse: isLocation, isFocused: focused, isScrollTarget }) => {
     return (
-        <div className={`chat ${isResponse ? "chat-start max-w-2xl w-max" : "chat-end"}`} data-is-scroll-target={isScrollTarget}>
-            <div className={`flex rounded-box whitespace-pre-wrap ${ !isResponse ? "max-w-[80%] bg-primary text-white" : "bg-white" } ${focused ? "" : "bg-opacity-80"} text-black`}>
+        <div className={`chat ${isResponse ? "chat-start" : "chat-end"}`} data-is-scroll-target={isScrollTarget}>
+            <div 
+                className={`flex rounded-box whitespace-pre-wrap 
+                ${!isResponse ? "bg-primary text-white" : "bg-white"} 
+                ${focused ? "" : "bg-opacity-80"} 
+                text-black max-w-full md:max-w-2xl`}
+            >
                 <div className={`w-2 bg-${focused ? "primary" : "transparent"} rounded-l-lg`} hidden={!isLocation}>
                 </div>
 
@@ -20,7 +25,8 @@ const ChatBubble: React.FC<Props> = ({ children, isResponse, isLocationResponse:
                 </div>
             </div>
         </div>
-    )
+    );
 };
+
 
 export default ChatBubble;

--- a/src/components/Chat/index.tsx
+++ b/src/components/Chat/index.tsx
@@ -30,6 +30,8 @@ const ChatComponent = () => {
 
   const socket = useAppStore(state => state.socket);
 
+  const isSidePanelOpen = useAppStore(state => state.isSidePanelOpen);
+
   // When the user submits a query, this will hold what they asked temporarily
   const [submittedQuery, setSubmittedQuery] = useState<null | string>(null);
 
@@ -56,6 +58,8 @@ const ChatComponent = () => {
 
   // Scroll to the bottom of the container with smooth animation
   useEffect(() => {
+    if(isSidePanelOpen) return;
+    
     const elems = containerRef.current?.querySelectorAll("[data-is-scroll-target]");
     if (elems && elems.length > 0) {
       const elem = elems[elems.length - 1];

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -22,6 +22,7 @@ const SidePanel: React.FC = () => {
     const location = useLocation();
     const user = useAppStore((state) => state.user);
     const accessToken = useAppStore((state) => state.accessToken);
+    const isSidePanelOpen = useAppStore((state) => state.isSidePanelOpen);
     const setisSidePanelOpen = useAppStore((state) => state.setisSidePanelOpen);
 
     const conversationPreviews = useAppStore((state) => state.conversationPreviews);
@@ -104,7 +105,7 @@ const SidePanel: React.FC = () => {
         <>
             <input id="sidepanel" type="checkbox" className="drawer-toggle" />
 
-            <div className="drawer-side h-full md:rounded-box bg-white text-base-neutral">
+            <div className={`drawer-side h-full md:rounded-box bg-white ${isSidePanelOpen ? 'bg-opacity-50' : 'bg-opacity-0'} text-base-neutral`}>
                 <label htmlFor="my-drawer" className="drawer-overlay"></label>
 
                 <div className="w-[275px] py-4 px-0 h-full flex flex-col justify-between">


### PR DESCRIPTION
Previously, the 50% opacity sidebar background was overlaid over the whole screen when the sidebar was closed. Additionally, in 77759d56f985874b119dc7d369cb9de602225c9e, changing it to a 100% opacity background made the solid-white background overlay the whole screen, making buttons visually invisible.

Now, the sidebar background is 100% when it's open and 0% when it's closed.